### PR TITLE
Change from String:: to CakeText:: because it was depreceated on vers…

### DIFF
--- a/Controller/ArosController.php
+++ b/Controller/ArosController.php
@@ -228,7 +228,7 @@ class ArosController extends AclAppController
 	    $methods = array();
 		foreach($actions as $k => $full_action)
     	{
-	    	$arr = String::tokenize($full_action, '/');
+	    	$arr = CakeText::tokenize($full_action, '/');
 	    	
 			if (count($arr) == 2)
 			{
@@ -282,7 +282,7 @@ class ArosController extends AclAppController
 	    
 	    foreach($actions as $full_action)
     	{
-	    	$arr = String::tokenize($full_action, '/');
+	    	$arr = CakeText::tokenize($full_action, '/');
 	    	
 			if (count($arr) == 2)
 			{
@@ -400,7 +400,7 @@ class ArosController extends AclAppController
         		
 	            foreach($actions as $full_action)
 		    	{
-			    	$arr = String::tokenize($full_action, '/');
+			    	$arr = CakeText::tokenize($full_action, '/');
 			    	
 					if (count($arr) == 2)
 					{

--- a/Controller/ArosController.php
+++ b/Controller/ArosController.php
@@ -226,38 +226,45 @@ class ArosController extends AclAppController
 	    $actions = $this->AclReflector->get_all_actions();
 	    
 	    $methods = array();
-		foreach($actions as $k => $full_action)
-    	{
-	    	$arr = CakeText::tokenize($full_action, '/');
-	    	
-			if (count($arr) == 2)
-			{
-				$plugin_name     = null;
-				$controller_name = $arr[0];
-				$action          = $arr[1];
-			}
-			elseif(count($arr) == 3)
-			{
-				$plugin_name     = $arr[0];
-				$controller_name = $arr[1];
-				$action          = $arr[2];
-			}
-			
-			if($controller_name == 'App')
-			{
-			    unset($actions[$k]);
-			}
-			else
-			{
-        		if(isset($plugin_name))
+            foreach($actions as $k => $full_action) {
+            
+                if (Configure::version() < '2.7') 
                 {
-                	$methods['plugin'][$plugin_name][$controller_name][] = array('name' => $action);
+                    $arr = String::tokenize($full_action, '/');
+                } 
+                else 
+                {
+                    $arr = CakeText::tokenize($full_action, '/');
+                }
+                
+                if (count($arr) == 2)
+                {
+                        $plugin_name     = null;
+                        $controller_name = $arr[0];
+                        $action          = $arr[1];
+                }
+                elseif(count($arr) == 3)
+                {
+                        $plugin_name     = $arr[0];
+                        $controller_name = $arr[1];
+                        $action          = $arr[2];
+                }
+
+                if($controller_name == 'App')
+                {
+                    unset($actions[$k]);
+                }
+            else
+            {
+                if(isset($plugin_name))
+                {
+                    $methods['plugin'][$plugin_name][$controller_name][] = array('name' => $action);
                 }
                 else
                 {
             	    $methods['app'][$controller_name][] = array('name' => $action);
                 }
-			}
+            }
     	}
     	
 	    $this->set('roles', $roles);
@@ -281,56 +288,63 @@ class ArosController extends AclAppController
 	    $methods     = array();
 	    
 	    foreach($actions as $full_action)
-    	{
-	    	$arr = CakeText::tokenize($full_action, '/');
-	    	
-			if (count($arr) == 2)
-			{
-				$plugin_name     = null;
-				$controller_name = $arr[0];
-				$action          = $arr[1];
-			}
-			elseif(count($arr) == 3)
-			{
-				$plugin_name     = $arr[0];
-				$controller_name = $arr[1];
-				$action          = $arr[2];
-			}
+            {
+                if (Configure::version() < '2.7') 
+                {
+                    $arr = String::tokenize($full_action, '/');
+                } 
+                else 
+                {
+                    $arr = CakeText::tokenize($full_action, '/');
+                }
+                
+                if (count($arr) == 2)
+                {
+                    $plugin_name     = null;
+                    $controller_name = $arr[0];
+                    $action          = $arr[1];
+                }
+                elseif(count($arr) == 3)
+                {
+                    $plugin_name     = $arr[0];
+                    $controller_name = $arr[1];
+                    $action          = $arr[2];
+                }
     		
-			if($controller_name != 'App')
-			{
+                if($controller_name != 'App')
+                {
     		    foreach($roles as $role)
-    	    	{
-    	    	    $aro_node = $this->Acl->Aro->node($role);
-    	            if(!empty($aro_node))
-    	            {
-    	                $aco_node = $this->Acl->Aco->node('controllers/' . $full_action);
-    	        	    if(!empty($aco_node))
-    	        	    {
-    	        	    	$authorized = $this->Acl->check($role, 'controllers/' . $full_action);
-    	        	    	
-    	        	    	$permissions[$role[Configure :: read('acl.aro.role.model')][$this->_get_role_primary_key_name()]] = $authorized ? 1 : 0 ;
-    					}
-    	            }
-    	    		else
-            	    {
-            	        /*
-            	         * No check could be done as the ARO is missing
-            	         */
-            	        $permissions[$role[Configure :: read('acl.aro.role.model')][$this->_get_role_primary_key_name()]] = -1;
-            	    }
-        		}
+                    {
+                        $aro_node = $this->Acl->Aro->node($role);
+                        if(!empty($aro_node))
+                        {
+                            $aco_node = $this->Acl->Aco->node('controllers/' . $full_action);
+                                if(!empty($aco_node))
+                                {
+                                    $authorized = $this->Acl->check($role, 'controllers/' . $full_action);
+
+                                    $permissions[$role[Configure :: read('acl.aro.role.model')][$this->_get_role_primary_key_name()]] = $authorized ? 1 : 0 ;
+                                }
+                            }
+                        else
+                        {
+                            /*
+                                                    * No check could be done as the ARO is missing
+                                                    */
+                            $permissions[$role[Configure :: read('acl.aro.role.model')][$this->_get_role_primary_key_name()]] = -1;
+                        }
+                    }
         		
-        		if(isset($plugin_name))
-                {
+                    if(isset($plugin_name))
+                    {
                 	$methods['plugin'][$plugin_name][$controller_name][] = array('name' => $action, 'permissions' => $permissions);
+                    }
+                    else
+                    {
+                        $methods['app'][$controller_name][] = array('name' => $action, 'permissions' => $permissions);
+                    }
                 }
-                else
-                {
-            	    $methods['app'][$controller_name][] = array('name' => $action, 'permissions' => $permissions);
-                }
-			}
-    	}
+            }   
  		
 	    $this->set('roles', $roles);
 	    $this->set('actions', $methods);
@@ -398,59 +412,66 @@ class ArosController extends AclAppController
             {
             	$actions = $this->AclReflector->get_all_actions();
         		
-	            foreach($actions as $full_action)
-		    	{
-			    	$arr = CakeText::tokenize($full_action, '/');
-			    	
-					if (count($arr) == 2)
-					{
-						$plugin_name     = null;
-						$controller_name = $arr[0];
-						$action          = $arr[1];
-					}
-					elseif(count($arr) == 3)
-					{
-						$plugin_name     = $arr[0];
-						$controller_name = $arr[1];
-						$action          = $arr[2];
-					}
+                foreach($actions as $full_action)
+                {
+                    if (Configure::version() < '2.7') 
+                    {
+                        $arr = String::tokenize($full_action, '/');
+                    } 
+                    else 
+                    {
+                        $arr = CakeText::tokenize($full_action, '/');
+                    }
 
-					if($controller_name != 'App')
-					{
-    					if(!isset($this->params['named']['ajax']))
-    					{
-        		    		$aco_node = $this->Acl->Aco->node('controllers/' . $full_action);
-        	        	    if(!empty($aco_node))
-        	        	    {
-        	        	    	$authorized = $this->Acl->check($user, 'controllers/' . $full_action);
-    
-        	        	    	$permissions[$user[$user_model_name][$this->_get_user_primary_key_name()]] = $authorized ? 1 : 0 ;
-        					}
-    					}
-    					
-    			    	if(isset($plugin_name))
-    		            {
-    		            	$methods['plugin'][$plugin_name][$controller_name][] = array('name' => $action, 'permissions' => $permissions);
-    		            }
-    		            else
-    		            {
-    		        	    $methods['app'][$controller_name][] = array('name' => $action, 'permissions' => $permissions);
-    		            }
-					}
-		    	}
-		    	
-		    	/*
-		    	 * Check if the user has specific permissions
-		    	 */
-		    	$count = $this->Aro->Permission->find('count', array('conditions' => array('Aro.id' => $user_aro[0]['Aro']['id'])));
-		    	if($count != 0)
-		    	{
-		    	    $this->set('user_has_specific_permissions', true);
-		    	}
-		    	else
-		    	{
-		    	    $this->set('user_has_specific_permissions', false);
-		    	}
+                    if (count($arr) == 2)
+                    {
+                        $plugin_name     = null;
+                        $controller_name = $arr[0];
+                        $action          = $arr[1];
+                    }
+                    elseif(count($arr) == 3)
+                    {
+                        $plugin_name     = $arr[0];
+                        $controller_name = $arr[1];
+                        $action          = $arr[2];
+                    }
+
+                    if($controller_name != 'App')
+                    {
+                        if(!isset($this->params['named']['ajax']))
+                        {
+                            $aco_node = $this->Acl->Aco->node('controllers/' . $full_action);
+                            if(!empty($aco_node))
+                            {
+                                $authorized = $this->Acl->check($user, 'controllers/' . $full_action);
+
+                                $permissions[$user[$user_model_name][$this->_get_user_primary_key_name()]] = $authorized ? 1 : 0 ;
+                            }
+                        }
+
+                        if(isset($plugin_name))
+                        {
+                            $methods['plugin'][$plugin_name][$controller_name][] = array('name' => $action, 'permissions' => $permissions);
+                        }
+                        else
+                        {
+                            $methods['app'][$controller_name][] = array('name' => $action, 'permissions' => $permissions);
+                        }
+                    }
+                }
+
+                /*
+                                * Check if the user has specific permissions
+                                */
+                $count = $this->Aro->Permission->find('count', array('conditions' => array('Aro.id' => $user_aro[0]['Aro']['id'])));
+                if($count != 0)
+                {
+                    $this->set('user_has_specific_permissions', true);
+                }
+                else
+                {
+                    $this->set('user_has_specific_permissions', false);
+                }
             }
             
             $this->set('user', $user);

--- a/Controller/Component/AclReflectorComponent.php
+++ b/Controller/Component/AclReflectorComponent.php
@@ -14,7 +14,7 @@ class AclReflectorComponent extends Component
 	
 	public function getPluginName($ctrlName = null)
 	{
-		$arr = String::tokenize($ctrlName, '/');
+		$arr = CakeText::tokenize($ctrlName, '/');
 		if (count($arr) == 2) {
 			return $arr[0];
 		} else {
@@ -23,7 +23,7 @@ class AclReflectorComponent extends Component
 	}
 	public function getPluginControllerName($ctrlName = null)
 	{
-		$arr = String::tokenize($ctrlName, '/');
+		$arr = CakeText::tokenize($ctrlName, '/');
 		if (count($arr) == 2) {
 			return $arr[1];
 		} else {

--- a/Controller/Component/AclReflectorComponent.php
+++ b/Controller/Component/AclReflectorComponent.php
@@ -5,7 +5,7 @@ class AclReflectorComponent extends Component
 
 	/****************************************************************************************/
     
-    public function initialize(Controller $controller)
+        public function initialize(Controller $controller)
 	{
 	    $this->controller = $controller;
 	}
@@ -14,7 +14,15 @@ class AclReflectorComponent extends Component
 	
 	public function getPluginName($ctrlName = null)
 	{
-		$arr = CakeText::tokenize($ctrlName, '/');
+                if (Configure::version() < '2.7') 
+                {
+                    $arr = String::tokenize($ctrlName, '/');
+                } 
+                else 
+                {
+                    $arr = CakeText::tokenize($ctrlName, '/');
+                }
+            
 		if (count($arr) == 2) {
 			return $arr[0];
 		} else {
@@ -23,8 +31,16 @@ class AclReflectorComponent extends Component
 	}
 	public function getPluginControllerName($ctrlName = null)
 	{
-		$arr = CakeText::tokenize($ctrlName, '/');
-		if (count($arr) == 2) {
+                if (Configure::version() < '2.7') 
+                {
+                    $arr = String::tokenize($ctrlName, '/');
+                } 
+                else 
+                {
+                    $arr = CakeText::tokenize($ctrlName, '/');
+                }
+	
+                if (count($arr) == 2) {
 			return $arr[1];
 		} else {
 			return false;


### PR DESCRIPTION
Change from String:: to CakeText:: because it was depreceated on version prior CakePHP 2.8